### PR TITLE
Add highlighting for literate Rzk LaTeX

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,14 +75,14 @@
       {
         "id": "literate rzk markdown",
         "aliases": [
-          "Literate Rzk Markdown",
-          "literate rzk markdown",
           "Literate Rzk-1 Markdown",
           "literate rzk-1 markdown",
-          "rzk markdown",
           "rzk-1 markdown",
-          "rzk-md",
-          "rzk-1-md"
+          "rzk-1-md",
+          "Literate Rzk Markdown",
+          "literate rzk markdown",
+          "rzk markdown",
+          "rzk-md"
         ],
         "extensions": [
           ".rzk.tex"
@@ -100,11 +100,18 @@
       {
         "id": "literate rzk latex",
         "aliases": [
+          "Literate Rzk-1 LaTeX",
+          "Literate Rzk-1 Latex",
+          "literate rzk-1 latex",
+          "Rzk-1 LaTeX",
+          "Rzk-1 Latex",
+          "rzk-1 latex",
+          "rzk-1-tex",
           "Literate Rzk LaTeX",
-          "Rzk LaTeX",
           "Literate Rzk Latex",
-          "Rzk Latex",
           "literate rzk latex",
+          "Rzk LaTeX",
+          "Rzk Latex",
           "rzk latex",
           "rzk-latex",
           "rzk-tex"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,19 @@
   "contributes": {
     "grammars": [
       {
+        "language": "rzk",
+        "scopeName": "source.rzk",
+        "path": "./syntaxes/rzk.tmLanguage.json"
+      },
+      {
+        "language": "literate rzk markdown",
+        "scopeName": "text.html.markdown.rzk",
+        "path": "./syntaxes/literate-rzk-markdown.tmLanguage.json",
+        "filenamePatterns": [
+          "*.rzk.md"
+        ]
+      },
+      {
         "path": "./syntaxes/rzk-markdown-injection.tmLanguage.json",
         "scopeName": "source.rzk.embedded.markdown",
         "injectTo": [
@@ -27,17 +40,19 @@
         }
       },
       {
-        "language": "rzk",
-        "scopeName": "source.rzk",
-        "path": "./syntaxes/rzk.tmLanguage.json"
+        "language": "literate rzk latex",
+        "scopeName": "text.tex.latex.rzk",
+        "path": "./syntaxes/literate-rzk-latex.tmLanguage.json"
       },
       {
-        "language": "literate rzk markdown",
-        "scopeName": "text.html.markdown.rzk",
-        "path": "./syntaxes/literate-rzk-markdown.tmLanguage.json",
-        "filenamePatterns": [
-          "*.rzk.md"
-        ]
+        "scopeName": "source.rzk.embedded.latex",
+        "path": "./syntaxes/rzk-latex-injection.tmLanguage.json",
+        "injectTo": [
+          "text.tex.latex.rzk"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.rzk": "rzk"
+        }
       }
     ],
     "languages": [
@@ -70,10 +85,10 @@
           "rzk-1-md"
         ],
         "extensions": [
-          ".rzk.md"
+          ".rzk.tex"
         ],
         "filenamePatterns": [
-          "*.rzk.md"
+          "*.rzk.tex"
         ],
         "configuration": "./language-configuration.json",
         "icon": {
@@ -81,6 +96,27 @@
           "dark": "./icons/rzk-dark.png"
         },
         "scopeName": "text.html.markdown.rzk"
+      },
+      {
+        "id": "literate rzk latex",
+        "aliases": [
+          "Literate Rzk LaTeX",
+          "Rzk LaTeX",
+          "Literate Rzk Latex",
+          "Rzk Latex",
+          "literate rzk latex",
+          "rzk latex",
+          "rzk-latex",
+          "rzk-tex"
+        ],
+        "extensions": [
+          ".rzk.tex"
+        ],
+        "icon": {
+          "light": "./icons/rzk-light.png",
+          "dark": "./icons/rzk-dark.png"
+        },
+        "scopeName": "text.tex.latex.rzk"
       }
     ]
   }

--- a/syntaxes/literate-rzk-latex.tmLanguage.json
+++ b/syntaxes/literate-rzk-latex.tmLanguage.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Literate Rzk LaTeX",
+  "scopeName": "text.tex.latex.rak",
+  "fileTypes": ["rzk.tex"],
+  "patterns": [
+    {
+      "include": "text.tex.latex"
+    }
+  ]
+}

--- a/syntaxes/rzk-latex-injection.tmLanguage.json
+++ b/syntaxes/rzk-latex-injection.tmLanguage.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Literate Rzk LaTeX Injection",
+  "scopeName": "source.rzk.embedded.latex",
+  "fileTypes": [],
+  "injectionSelector": "L:text.tex.latex.rzk",
+  "patterns": [
+    {
+      "begin": "((\\\\)begin)({)(code)(})",
+      "end": "((\\\\)end)({)(code)(})",
+      "name": "meta.function.environment.general.latex",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.be.latex"
+        },
+        "2": {
+          "name": "punctuation.definition.function.latex"
+        },
+        "3": {
+          "name": "punctuation.definition.arguments.begin.latex"
+        },
+        "4": {
+          "name": "variable.parameter.function.latex"
+        },
+        "5": {
+          "name": "punctuation.definition.arguments.end.latex"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "support.function.be.latex"
+        },
+        "2": {
+          "name": "punctuation.definition.function.latex"
+        },
+        "3": {
+          "name": "punctuation.definition.arguments.begin.latex"
+        },
+        "4": {
+          "name": "variable.parameter.function.latex"
+        },
+        "5": {
+          "name": "punctuation.definition.arguments.end.latex"
+        }
+      },
+      "contentName": "meta.embedded.block.rzk",
+      "patterns": [
+        {
+          "include": "source.rzk"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Does what the title says. Note that I have only tested this code (lightly) with Agda, as I don't know of any literate Rzk LaTeX files. :)
At least this gives a basis for further development.

Resolves #3.