### PR TITLE
Use YAML as main grammar format and autoconvert to JSON

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "request": "launch",
       "skipFiles": ["<node_internals>/**"],
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
-      "preLaunchTask": "Convert YAML TextMate Grammar to JSON"
+      "preLaunchTask": "Convert YAML TextMate Grammars to JSON"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,15 +3,15 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-    "version": "0.2.0",
-    "configurations": [
-      {
-        "name": "Extension",
-        "type": "extensionHost",
-        "request": "launch",
-        "skipFiles": ["<node_internals>/**"],
-        "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
-        // "preLaunchTask": "Convert YAML TextMate Grammar to JSON"
-      }
-    ]
-  }
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "preLaunchTask": "Convert YAML TextMate Grammar to JSON"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,14 +1,18 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
-    "version": "2.0.0",
-    "tasks": [
-      {
-        "label": "Convert YAML TextMate Grammar to JSON",
-        "type": "shell",
-        "command": "bash",
-        "args": ["./convert_yml_to_json.sh"],
-        "problemMatcher": []
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Convert YAML TextMate Grammars to JSON",
+      "type": "shell",
+      "command": "bash",
+      "args": ["convert_yml_to_json.sh"],
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
       }
-    ]
-  }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Convert YAML TextMate Grammar to JSON",
+        "type": "shell",
+        "command": "bash",
+        "args": ["./convert_yml_to_json.sh"],
+        "problemMatcher": []
+      }
+    ]
+  }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,4 @@
+.vscode/**
 .vscode-test/**
 .gitignore
 vsc-extension-quickstart.md

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,3 @@
-.vscode/**
 .vscode-test/**
 .gitignore
 vsc-extension-quickstart.md

--- a/convert_yml_to_json.sh
+++ b/convert_yml_to_json.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+for file in syntaxes/*.tmLanguage.yaml syntaxes/*.tmLanguage.yml
+do
+  if [ -f "$file" ]; then
+    npx js-yaml "$file" > "${file%.*}.json"
+  fi
+done

--- a/convert_yml_to_json.sh
+++ b/convert_yml_to_json.sh
@@ -3,6 +3,6 @@
 for file in syntaxes/*.tmLanguage.yaml syntaxes/*.tmLanguage.yml
 do
   if [ -f "$file" ]; then
-    npx js-yaml "$file" > "${file%.*}.json"
+    npx -y js-yaml "$file" > "${file%.*}.json"
   fi
 done

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
         "scopeName": "text.html.markdown.rzk"
       }
     ]
+  },
+  "devDependencies": {
+    "js-yaml": "^4.1.0"
   }
 }

--- a/syntaxes/rzk.tmLanguage.json
+++ b/syntaxes/rzk.tmLanguage.json
@@ -1,286 +1,286 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "rzk-1",
-	"patterns": [
-		{
-			"match": "^(#lang)\\s+([^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r]*)\\b\\s*$",
-			"captures": {
-				"1": {
-					"name": "keyword.control"
-				},
-				"2": {
-					"name": "entity.name.label"
-				}
-			}
-		},
-		{
-			"match": "^(#check|#compute(-whnf|-nf)?|#set-option|#unset-option)\\b[^-]",
-			"captures": {
-				"1": {
-					"name": "keyword.control"
-				}
-			}
-		},
-		{
-			"match": "^(#section|#end)(\\s+[^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r]*)?\\b",
-			"captures": {
-				"1": {
-					"name": "keyword.control"
-				},
-				"2": {
-					"name": "support.constant.property-value"
-				}
-			}
-		},
-		{
-			"match": "^(#assume|#variable|#variables)\\s+([^\\-\\?\\!\\.\\\\;\\:,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r][^\\.\\\\;\\:,#\\\"\\]\\[\\)\\(\\}\\{><\\|]*)\\b",
-			"captures": {
-				"1": {
-					"name": "meta.preprocessor"
-				},
-				"2": {
-					"name": "variable.rzk"
-				}
-			}
-		},
-		{
-			"match": "^(#def|#define|#postulate)\\s+([^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r]*)\\b(\\s+(uses)\\s+\\(([^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\|][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\|]*)\\))?",
-			"captures": {
-				"1": {
-					"name": "meta.preprocessor"
-				},
-				"2": {
-					"name": "entity.name.function"
-				},
-				"4": {
-					"name": "support.constant.property-value"
-				},
-				"5": {
-					"name": "variable.parameter.rzk"
-				}
-			}
-		},
-		{
-			"include": "#strings"
-		},
-		{
-			"include": "#terms"
-		}
-	],
-	"repository": {
-		"terms": {
-			"patterns": [
-				{
-					"include": "#index-types"
-				},
-				{
-					"include": "#builtins"
-				},
-				{
-					"include": "#params"
-				},
-				{
-					"include": "#comments"
-				},
-				{
-					"include": "#ext-types"
-				},
-				{
-					"include": "#lambda-abstractions"
-				}
-			]
-		},
-		"builtins": {
-			"patterns": [
-				{
-					"name": "entity.name.type.rzk",
-					"match": "(\\b(CUBE|TOPE|U|𝒰|Sigma|1|2|𝟙|𝟚)\\b|(∑|Σ))"
-				},
-				{
-					"name": "string.regexp",
-					"match": "((\\*_1|⋆)|\\b(0_2|1_2|TOP|BOT)\\b|(===|<=|\\\\/|/\\\\|⊤|⊥))"
-				},
-				{
-					"name": "constant.character",
-					"match": "\\b(recOR|rec∨|recBOT|rec⊥|idJ|refl|first|second|π₁|π₂)\\b"
-				},
-				{
-					"name": "keyword.control",
-					"match": "\\b(as)\\b"
-				}
-			]
-		},
-		"param-identifiers": {
-			"patterns": [
-				{
-					"match": "[^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n]*",
-					"name": "variable.parameter.rzk"
-				}
-			]
-		},
-		"param-topes": {
-			"patterns": [
-				{
-					"match": "\\|([^}]*)",
-					"captures": {
-						"1": {
-							"name": "string.interpolated",
-							"patterns": [
-								{
-									"include": "#builtins"
-								}
-							]
-						}
-					}
-				}
-			]
-		},
-		"ext-type-topes": {
-			"patterns": [
-				{
-					"match": "([^\\|]*)\\|->",
-					"captures": {
-						"1": {
-							"name": "string.interpolated",
-							"patterns": [
-								{
-									"include": "#builtins"
-								}
-							]
-						}
-					}
-				}
-			]
-		},
-		"ext-types": {
-			"patterns": [
-				{
-					"begin": "\\[",
-					"end": "\\]",
-					"patterns": [
-						{
-							"include": "#ext-type-topes"
-						},
-						{
-							"include": "#terms"
-						}
-					]
-				}
-			]
-		},
-		"index-types": {
-			"patterns": [
-				{
-					"begin": "_{",
-					"end": "}",
-					"name": "comment.block",
-					"patterns": [
-						{
-							"include": "#builtins"
-						},
-						{
-							"include": "#index-types"
-						},
-						{
-							"include": "#comments"
-						}
-					]
-				}
-			]
-		},
-		"params": {
-			"patterns": [
-				{
-					"begin": "\\(\\s*([^{:]+)\\s*:",
-					"end": "\\)",
-					"beginCaptures": {
-						"1": {
-							"patterns": [
-								{
-									"include": "#param-identifiers"
-								},
-								{
-									"include": "#builtins"
-								},
-								{
-									"include": "#comments"
-								}
-							]
-						}
-					},
-					"patterns": [
-						{
-							"include": "#terms"
-						}
-					]
-				},
-				{
-					"begin": "{\\s*([^:]+)\\s*:",
-					"end": "}",
-					"beginCaptures": {
-						"1": {
-							"patterns": [
-								{
-									"include": "#param-identifiers"
-								},
-								{
-									"include": "#builtins"
-								},
-								{
-									"include": "#comments"
-								}
-							]
-						}
-					},
-					"patterns": [
-						{
-							"include": "#param-topes"
-						},
-						{
-							"include": "#terms"
-						}
-					]
-				}
-			]
-		},
-		"lambda-abstractions": {
-			"patterns": [
-				{
-					"begin": " (\\\\)\\b",
-					"end": "(->|→)",
-					"patterns": [
-						{
-							"include": "#params"
-						},
-						{
-							"include": "#param-identifiers"
-						},
-						{
-							"include": "#comments"
-						}
-					]
-				}
-			]
-		},
-		"comments": {
-			"patterns": [
-				{
-					"name": "comment.line.rzk",
-					"match": "(\\s+|^)--\\s+.*$"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.double.rzk",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.rzk",
-					"match": "\\\\."
-				}
-			]
-		}
-	},
-	"scopeName": "source.rzk"
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "rzk-1",
+  "patterns": [
+    {
+      "match": "^(#lang)\\s+([^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r]*)\\b\\s*$",
+      "captures": {
+        "1": {
+          "name": "keyword.control"
+        },
+        "2": {
+          "name": "entity.name.label"
+        }
+      }
+    },
+    {
+      "match": "^(#check|#compute(-whnf|-nf)?|#set-option|#unset-option)\\b[^-]",
+      "captures": {
+        "1": {
+          "name": "keyword.control"
+        }
+      }
+    },
+    {
+      "match": "^(#section|#end)(\\s+[^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r]*)?\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.control"
+        },
+        "2": {
+          "name": "support.constant.property-value"
+        }
+      }
+    },
+    {
+      "match": "^(#assume|#variable|#variables)\\s+([^\\-\\?\\!\\.\\\\;\\:,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r][^\\.\\\\;\\:,#\\\"\\]\\[\\)\\(\\}\\{><\\|]*)\\b",
+      "captures": {
+        "1": {
+          "name": "meta.preprocessor"
+        },
+        "2": {
+          "name": "variable.rzk"
+        }
+      }
+    },
+    {
+      "match": "^(#def|#define|#postulate)\\s+([^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n\\r]*)\\b(\\s+(uses)\\s+\\(([^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\|][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\|]*)\\))?",
+      "captures": {
+        "1": {
+          "name": "meta.preprocessor"
+        },
+        "2": {
+          "name": "entity.name.function"
+        },
+        "4": {
+          "name": "support.constant.property-value"
+        },
+        "5": {
+          "name": "variable.parameter.rzk"
+        }
+      }
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#terms"
+    }
+  ],
+  "repository": {
+    "terms": {
+      "patterns": [
+        {
+          "include": "#index-types"
+        },
+        {
+          "include": "#builtins"
+        },
+        {
+          "include": "#params"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#ext-types"
+        },
+        {
+          "include": "#lambda-abstractions"
+        }
+      ]
+    },
+    "builtins": {
+      "patterns": [
+        {
+          "name": "entity.name.type.rzk",
+          "match": "(\\b(CUBE|TOPE|U|𝒰|Sigma|1|2|𝟙|𝟚)\\b|(∑|Σ))"
+        },
+        {
+          "name": "string.regexp",
+          "match": "((\\*_1|⋆)|\\b(0_2|1_2|TOP|BOT)\\b|(===|<=|\\\\/|/\\\\|⊤|⊥))"
+        },
+        {
+          "name": "constant.character",
+          "match": "\\b(recOR|rec∨|recBOT|rec⊥|idJ|refl|first|second|π₁|π₂)\\b"
+        },
+        {
+          "name": "keyword.control",
+          "match": "\\b(as)\\b"
+        }
+      ]
+    },
+    "param-identifiers": {
+      "patterns": [
+        {
+          "match": "[^\\-\\?\\!\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n][^\\.\\\\;,#\\\"\\]\\[\\)\\(\\}\\{><\\| \\t\\n]*",
+          "name": "variable.parameter.rzk"
+        }
+      ]
+    },
+    "param-topes": {
+      "patterns": [
+        {
+          "match": "\\|([^}]*)",
+          "captures": {
+            "1": {
+              "name": "string.interpolated",
+              "patterns": [
+                {
+                  "include": "#builtins"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "ext-type-topes": {
+      "patterns": [
+        {
+          "match": "([^\\|]*)\\|->",
+          "captures": {
+            "1": {
+              "name": "string.interpolated",
+              "patterns": [
+                {
+                  "include": "#builtins"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "ext-types": {
+      "patterns": [
+        {
+          "begin": "\\[",
+          "end": "\\]",
+          "patterns": [
+            {
+              "include": "#ext-type-topes"
+            },
+            {
+              "include": "#terms"
+            }
+          ]
+        }
+      ]
+    },
+    "index-types": {
+      "patterns": [
+        {
+          "begin": "_{",
+          "end": "}",
+          "name": "comment.block",
+          "patterns": [
+            {
+              "include": "#builtins"
+            },
+            {
+              "include": "#index-types"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        }
+      ]
+    },
+    "params": {
+      "patterns": [
+        {
+          "begin": "\\(\\s*([^{:]+)\\s*:",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#param-identifiers"
+                },
+                {
+                  "include": "#builtins"
+                },
+                {
+                  "include": "#comments"
+                }
+              ]
+            }
+          },
+          "patterns": [
+            {
+              "include": "#terms"
+            }
+          ]
+        },
+        {
+          "begin": "{\\s*([^:]+)\\s*:",
+          "end": "}",
+          "beginCaptures": {
+            "1": {
+              "patterns": [
+                {
+                  "include": "#param-identifiers"
+                },
+                {
+                  "include": "#builtins"
+                },
+                {
+                  "include": "#comments"
+                }
+              ]
+            }
+          },
+          "patterns": [
+            {
+              "include": "#param-topes"
+            },
+            {
+              "include": "#terms"
+            }
+          ]
+        }
+      ]
+    },
+    "lambda-abstractions": {
+      "patterns": [
+        {
+          "begin": " (\\\\)\\b",
+          "end": "(->|→)",
+          "patterns": [
+            {
+              "include": "#params"
+            },
+            {
+              "include": "#param-identifiers"
+            },
+            {
+              "include": "#comments"
+            }
+          ]
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.rzk",
+          "match": "(\\s+|^)--\\s+.*$"
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.double.rzk",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.rzk",
+          "match": "\\\\."
+        }
+      ]
+    }
+  },
+  "scopeName": "source.rzk"
 }

--- a/syntaxes/rzk.tmLanguage.json
+++ b/syntaxes/rzk.tmLanguage.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "comment": "This TextMate Grammar file has been generated from a YAML file.",
   "name": "rzk-1",
   "patterns": [
     {

--- a/syntaxes/rzk.tmLanguage.yml
+++ b/syntaxes/rzk.tmLanguage.yml
@@ -1,4 +1,5 @@
 $schema: https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json
+comment: This TextMate Grammar file has been generated from a YAML file.
 name: rzk-1
 patterns:
   - match: ^(#lang)\s+([^\-\?\!\.\\;,#\"\]\[\)\(\}\{><\|

--- a/syntaxes/rzk.tmLanguage.yml
+++ b/syntaxes/rzk.tmLanguage.yml
@@ -1,0 +1,143 @@
+$schema: https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json
+name: rzk-1
+patterns:
+  - match: ^(#lang)\s+([^\-\?\!\.\\;,#\"\]\[\)\(\}\{><\|
+      \t\n\r][^\.\\;,#\"\]\[\)\(\}\{><\| \t\n\r]*)\b\s*$
+    captures:
+      "1":
+        name: keyword.control
+      "2":
+        name: entity.name.label
+  - match: ^(#check|#compute(-whnf|-nf)?|#set-option|#unset-option)\b[^-]
+    captures:
+      "1":
+        name: keyword.control
+  - match: ^(#section|#end)(\s+[^\-\?\!\.\\;,#\"\]\[\)\(\}\{><\|
+      \t\n\r][^\.\\;,#\"\]\[\)\(\}\{><\| \t\n\r]*)?\b
+    captures:
+      "1":
+        name: keyword.control
+      "2":
+        name: support.constant.property-value
+  - match:
+      ^(#assume|#variable|#variables)\s+([^\-\?\!\.\\;\:,#\"\]\[\)\(\}\{><\|
+      \t\n\r][^\.\\;\:,#\"\]\[\)\(\}\{><\|]*)\b
+    captures:
+      "1":
+        name: meta.preprocessor
+      "2":
+        name: variable.rzk
+  - match: ^(#def|#define|#postulate)\s+([^\-\?\!\.\\;,#\"\]\[\)\(\}\{><\|
+      \t\n\r][^\.\\;,#\"\]\[\)\(\}\{><\|
+      \t\n\r]*)\b(\s+(uses)\s+\(([^\-\?\!\.\\;,#\"\]\[\)\(\}\{><\|][^\.\\;,#\"\]\[\)\(\}\{><\|]*)\))?
+    captures:
+      "1":
+        name: meta.preprocessor
+      "2":
+        name: entity.name.function
+      "4":
+        name: support.constant.property-value
+      "5":
+        name: variable.parameter.rzk
+  - include: "#strings"
+  - include: "#terms"
+repository:
+  terms:
+    patterns:
+      - include: "#index-types"
+      - include: "#builtins"
+      - include: "#params"
+      - include: "#comments"
+      - include: "#ext-types"
+      - include: "#lambda-abstractions"
+  builtins:
+    patterns:
+      - name: entity.name.type.rzk
+        match: (\b(CUBE|TOPE|U|𝒰|Sigma|1|2|𝟙|𝟚)\b|(∑|Σ))
+      - name: string.regexp
+        match: ((\*_1|⋆)|\b(0_2|1_2|TOP|BOT)\b|(===|<=|\\/|/\\|⊤|⊥))
+      - name: constant.character
+        match: \b(recOR|rec∨|recBOT|rec⊥|idJ|refl|first|second|π₁|π₂)\b
+      - name: keyword.control
+        match: \b(as)\b
+  param-identifiers:
+    patterns:
+      - match:
+          '[^\-\?\!\.\\;,#\"\]\[\)\(\}\{><\| \t\n][^\.\\;,#\"\]\[\)\(\}\{><\|
+          \t\n]*'
+        name: variable.parameter.rzk
+  param-topes:
+    patterns:
+      - match: \|([^}]*)
+        captures:
+          "1":
+            name: string.interpolated
+            patterns:
+              - include: "#builtins"
+  ext-type-topes:
+    patterns:
+      - match: ([^\|]*)\|->
+        captures:
+          "1":
+            name: string.interpolated
+            patterns:
+              - include: "#builtins"
+  ext-types:
+    patterns:
+      - begin: \[
+        end: \]
+        patterns:
+          - include: "#ext-type-topes"
+          - include: "#terms"
+  index-types:
+    patterns:
+      - begin: _{
+        end: "}"
+        name: comment.block
+        patterns:
+          - include: "#builtins"
+          - include: "#index-types"
+          - include: "#comments"
+  params:
+    patterns:
+      - begin: "\\(\\s*([^{:]+)\\s*:"
+        end: \)
+        beginCaptures:
+          "1":
+            patterns:
+              - include: "#param-identifiers"
+              - include: "#builtins"
+              - include: "#comments"
+        patterns:
+          - include: "#terms"
+      - begin: "{\\s*([^:]+)\\s*:"
+        end: "}"
+        beginCaptures:
+          "1":
+            patterns:
+              - include: "#param-identifiers"
+              - include: "#builtins"
+              - include: "#comments"
+        patterns:
+          - include: "#param-topes"
+          - include: "#terms"
+  lambda-abstractions:
+    patterns:
+      - begin: " (\\\\)\\b"
+        end: (->|→)
+        patterns:
+          - include: "#params"
+          - include: "#param-identifiers"
+          - include: "#comments"
+  comments:
+    patterns:
+      - name: comment.line.rzk
+        match: (\s+|^)--\s+.*$
+  strings:
+    name: string.quoted.double.rzk
+    begin: '"'
+    end: '"'
+    patterns:
+      - name: constant.character.escape.rzk
+        match: \\.
+scopeName: source.rzk


### PR DESCRIPTION
Here's some more code from my own highlighting project that I thought you might find useful. 😄

In my humble opinion, YAML is a superior format for writing grammar files. This PR makes it possible to use that file format for a better reading and development experience. Observe how the YAML file generally requires fewer escape characters and is half the length of its JSON counterpart!
I've also added a script that takes care of automatically converting the YAML file to JSON so that VSCode can understand it.   

As an extension of this PR, I can add Jinja2 templating, which enables template programming using the Jinja2 format. At least I personally found this useful to make my regular expressions more consistent and to increase the maintainability of my grammar files.