### PR TITLE
Preview button for Literate Rzk

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
   "tasks": [
     {
       "label": "Convert YAML TextMate Grammars to JSON",
-      "type": "shell",
+      "type": "process",
       "command": "bash",
       "args": ["convert_yml_to_json.sh"],
       "problemMatcher": [],

--- a/package.json
+++ b/package.json
@@ -128,7 +128,17 @@
         },
         "scopeName": "text.tex.latex.rzk"
       }
-    ]
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "when": "resourceLangId == 'literate rzk markdown'",
+          "command": "markdown.showPreviewToSide",
+          "alt": "markdown.showPreview",
+          "group": "navigation"
+        }
+      ]
+    }
   },
   "devDependencies": {
     "js-yaml": "^4.1.0"


### PR DESCRIPTION
Added an entry to the `"contributes"` object in `package.json` that brings back the preview button for Literate Rzk Markdown