### PR TITLE
Rzk auto-installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.3.1",
       "dependencies": {
         "@octokit/rest": "^19.0.13",
-        "semver": "^7.5.3"
+        "semver": "^7.5.3",
+        "tar": "^6.1.15"
       },
       "devDependencies": {
         "@types/node": "^20.3.1",
         "@types/semver": "^7.5.0",
+        "@types/tar": "^6.1.5",
         "@types/vscode": "^1.79.1",
         "js-yaml": "^4.1.0",
         "typescript": "^5.1.3"
@@ -191,6 +193,25 @@
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
+    "node_modules/@types/tar": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.5.tgz",
+      "integrity": "sha512-qm2I/RlZij5RofuY7vohTpYNaYcrSQlN2MyjucQc7ZweDwaEWkdN/EeNh6e9zjK6uEm6PwjdMXkcj05BxZdX1Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "minipass": "^4.0.0"
+      }
+    },
+    "node_modules/@types/tar/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@types/vscode": {
       "version": "1.79.1",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.79.1.tgz",
@@ -208,10 +229,40 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
@@ -239,6 +290,48 @@
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dependencies": {
         "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       },
       "engines": {
         "node": ">=10"
@@ -280,6 +373,22 @@
       },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
+      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,13 @@
     "": {
       "name": "rzk-1-experimental-highlighting",
       "version": "0.3.1",
+      "dependencies": {
+        "@octokit/rest": "^19.0.13",
+        "semver": "^7.5.3"
+      },
       "devDependencies": {
         "@types/node": "^20.3.1",
+        "@types/semver": "^7.5.0",
         "@types/vscode": "^1.79.1",
         "js-yaml": "^4.1.0",
         "typescript": "^5.1.3"
@@ -17,10 +22,173 @@
         "vscode": "^1.79.1"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+      "dependencies": {
+        "@octokit/auth-token": "^3.0.0",
+        "@octokit/graphql": "^5.0.0",
+        "@octokit/request": "^6.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+      "dependencies": {
+        "@octokit/request": "^6.0.0",
+        "@octokit/types": "^9.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+      "dependencies": {
+        "@octokit/tsconfig": "^1.0.2",
+        "@octokit/types": "^9.2.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=4"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
+      "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
+      "dependencies": {
+        "@octokit/types": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+      "dependencies": {
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^9.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "19.0.13",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
+      "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
+      "dependencies": {
+        "@octokit/core": "^4.2.1",
+        "@octokit/plugin-paginate-rest": "^6.1.2",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@octokit/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
+    },
+    "node_modules/@octokit/types": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.3.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
       "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/@types/vscode": {
@@ -35,6 +203,24 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -46,6 +232,63 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/typescript": {
       "version": "5.1.3",
@@ -59,6 +302,35 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -159,7 +159,14 @@
           "group": "navigation"
         }
       ]
-    }
+    },
+    "commands": [
+      {
+        "command": "rzk.clearLocalInstallations",
+        "title": "Rzk [Debug]: Clear local Rzk installation",
+        "when": "inDebugMode"
+      }
+    ]
   },
   "devDependencies": {
     "@types/node": "^20.3.1",

--- a/package.json
+++ b/package.json
@@ -163,8 +163,13 @@
   },
   "devDependencies": {
     "@types/node": "^20.3.1",
+    "@types/semver": "^7.5.0",
     "@types/vscode": "^1.79.1",
     "js-yaml": "^4.1.0",
     "typescript": "^5.1.3"
+  },
+  "dependencies": {
+    "@octokit/rest": "^19.0.13",
+    "semver": "^7.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -164,12 +164,14 @@
   "devDependencies": {
     "@types/node": "^20.3.1",
     "@types/semver": "^7.5.0",
+    "@types/tar": "^6.1.5",
     "@types/vscode": "^1.79.1",
     "js-yaml": "^4.1.0",
     "typescript": "^5.1.3"
   },
   "dependencies": {
     "@octokit/rest": "^19.0.13",
-    "semver": "^7.5.3"
+    "semver": "^7.5.3",
+    "tar": "^6.1.15"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,19 +1,59 @@
 import * as vscode from 'vscode';
+import { spawnSync } from 'node:child_process';
 import { output } from './logging';
 import { legend, DocumentSemanticTokensProvider } from './semanticTokens';
 import { installRzkIfNotExists } from './installRzk';
 
-// Inspired by https://github.com/microsoft/vscode-extension-samples/tree/main/semantic-tokens-sample
+function locateRzk(context: vscode.ExtensionContext) {
+  let path =
+    vscode.workspace.getConfiguration().get<string | null>('rzk.path') ?? null;
+  // Probe 1 - extension settings
+  if (path) {
+    const result = spawnSync(path, ['version']);
+    if (result.status === 0) {
+      return path;
+    } else {
+      output.appendLine(
+        'The configured `rzk.path` option does not point to a valid rzk executable'
+      );
+    }
+  }
+  // Probe 2 - global PATH
+  const binExtension = process.platform === 'win32' ? '.exe' : '';
+  path = 'rzk' + binExtension;
+  let result = spawnSync(path, ['version']);
+  if (result.status === 0) {
+    return path;
+  } else {
+    output.appendLine('Cannot find rzk globally');
+  }
+
+  // Probe 3 - extension storage bin folder
+  path = context.globalStorageUri.with({
+    path: context.globalStorageUri.path + '/bin/rzk' + binExtension,
+  }).path;
+  result = spawnSync(path, ['version']);
+  if (result.status === 0) {
+    return path;
+  }
+
+  return null;
+}
 
 export function activate(context: vscode.ExtensionContext) {
   output.appendLine('Rzk extension activated.');
-  context.subscriptions.push(
-    vscode.languages.registerDocumentSemanticTokensProvider(
-      ['rzk', 'literate rzk markdown'],
-      new DocumentSemanticTokensProvider(),
-      legend
-    )
-  );
+
+  const rzkPath = locateRzk(context);
+
+  if (rzkPath) {
+    context.subscriptions.push(
+      vscode.languages.registerDocumentSemanticTokensProvider(
+        ['rzk', 'literate rzk markdown'],
+        new DocumentSemanticTokensProvider(rzkPath),
+        legend
+      )
+    );
+  }
 
   const binFolder = context.globalStorageUri.with({
     path: context.globalStorageUri.path + '/bin',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,9 +55,7 @@ export function activate(context: vscode.ExtensionContext) {
     );
   }
 
-  const binFolder = context.globalStorageUri.with({
-    path: context.globalStorageUri.path + '/bin',
-  });
+  const binFolder = vscode.Uri.joinPath(context.globalStorageUri, 'bin');
 
   installRzkIfNotExists({ binFolder });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { output } from './logging';
 import { legend, DocumentSemanticTokensProvider } from './semanticTokens';
+import { installRzkIfNotExists } from './installRzk';
 
 // Inspired by https://github.com/microsoft/vscode-extension-samples/tree/main/semantic-tokens-sample
 
@@ -13,4 +14,10 @@ export function activate(context: vscode.ExtensionContext) {
       legend
     )
   );
+
+  const binFolder = context.globalStorageUri.with({
+    path: context.globalStorageUri.path + '/bin',
+  });
+
+  installRzkIfNotExists({ binFolder });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { spawnSync } from 'node:child_process';
 import { output } from './logging';
 import { legend, DocumentSemanticTokensProvider } from './semanticTokens';
-import { installRzkIfNotExists } from './installRzk';
+import { clearLocalInstallations, installRzkIfNotExists } from './installRzk';
 
 function locateRzk(context: vscode.ExtensionContext) {
   let path =
@@ -58,4 +58,8 @@ export function activate(context: vscode.ExtensionContext) {
   const binFolder = vscode.Uri.joinPath(context.globalStorageUri, 'bin');
 
   installRzkIfNotExists({ binFolder });
+
+  vscode.commands.registerCommand('rzk.clearLocalInstallations', () => {
+    clearLocalInstallations(binFolder);
+  });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import { spawnSync } from 'node:child_process';
+import { output } from './logging';
 import { type TokenModifier, type TokenType, legend } from './semanticTokens';
 
 // Inspired by https://github.com/microsoft/vscode-extension-samples/tree/main/semantic-tokens-sample
 
-let output = vscode.window.createOutputChannel('Rzk');
 export function activate(context: vscode.ExtensionContext) {
   output.appendLine('Rzk extension activated.');
   context.subscriptions.push(

--- a/src/githubReleases.ts
+++ b/src/githubReleases.ts
@@ -1,0 +1,86 @@
+import semver from 'semver';
+import { Octokit, type RestEndpointMethodTypes } from '@octokit/rest';
+import { output } from './logging';
+
+// TODO: use an API token to avoid low rate limits
+const octokit = new Octokit();
+
+/** In semver range format */
+const supportedRzkVersions = '>=0.4.1 <1.0.0';
+
+type Release =
+  RestEndpointMethodTypes['repos']['listReleases']['response']['data'][number];
+type RzkPlatform = 'Windows' | 'macOS' | 'Linux';
+
+const platformMapping: Partial<Record<NodeJS.Platform, RzkPlatform>> = {
+  win32: 'Windows',
+  darwin: 'macOS',
+  linux: 'Linux',
+};
+
+function getReleaseAssetName(release: Release) {
+  const platform = platformMapping[process.platform];
+  if (!platform) {
+    throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+  return `rzk-${release.tag_name}-${platform}-X64.tar.gz`;
+}
+
+/**
+ * Checks whether the given rzk version is compatible with the extension
+ * @param version A version string, e.g. "1.3.2" or "v0.4.1.1"
+ */
+export function isCompatibleVersion(version: string) {
+  return semver.satisfies(semver.coerce(version) ?? '', supportedRzkVersions);
+}
+
+/**
+ * Finds the latest release on GitHub that is compatible with the extension and returns its information.
+ */
+export async function fetchLatestCompatibleRelease(): Promise<
+  Release | undefined
+> {
+  // TODO: implement pagination in case no release matches the criteria in the default page size
+  const { data: releases } = await octokit.rest.repos.listReleases({
+    owner: 'fizruk',
+    repo: 'rzk',
+  });
+  // Find the latest release that satisfies the version range the extension supports
+  //   and has an asset for the current platform
+  const latestRelease = releases.find(
+    (release) =>
+      isCompatibleVersion(release.tag_name) &&
+      release.assets.find(
+        (asset) => asset.name === getReleaseAssetName(release)
+      )
+  );
+  return latestRelease;
+}
+
+/**
+ * Fetches the appropriate executable file from GitHub for the current platform
+ */
+export async function fetchReleaseBinary(release: Release) {
+  const asset = release.assets.find(
+    (asset) => asset.name === getReleaseAssetName(release)
+  );
+  if (!asset) {
+    output.appendLine(
+      `Error: ${getReleaseAssetName(release)} not found in release ${
+        release.tag_name
+      }`
+    );
+    return undefined;
+  }
+  const { data } = await octokit.rest.repos.getReleaseAsset({
+    owner: 'fizruk',
+    repo: 'rzk',
+    asset_id: asset.id,
+    headers: {
+      Accept: 'application/octet-stream',
+    },
+  });
+  // The "Accept" header affects the type of the returned data, which is not reflected in the typings
+  const binary = data as unknown as ArrayBuffer;
+  return binary;
+}

--- a/src/installRzk.ts
+++ b/src/installRzk.ts
@@ -34,7 +34,7 @@ export async function installRzkIfNotExists({
 }) {
   const path = getUserRzkPath();
   if (path != null) {
-    output.appendLine(`Using rzk from "${path}"`);
+    output.appendLine(`Using rzk from "${path === 'rzk' ? 'PATH' : path}"`);
     return;
   }
   // Create the bin folder (recursively) if it doesn't exist
@@ -79,7 +79,14 @@ export async function installRzkIfNotExists({
     )
     .then(async (value) => {
       if (value === 'Yes') {
-        await installLatestRzk(binFolder);
+        await vscode.window.withProgress(
+          {
+            title: 'Installing rzk...',
+            location: vscode.ProgressLocation.Notification,
+            cancellable: false,
+          },
+          (progress) => installLatestRzk(binFolder)
+        );
       }
     });
 }
@@ -139,7 +146,14 @@ async function checkForUpdates(binPath: string, binFolder: vscode.Uri) {
     .then(async (value) => {
       if (value === 'Yes') {
         output.appendLine('Updating local rzk version');
-        await installLatestRzk(binFolder);
+        await vscode.window.withProgress(
+          {
+            title: 'Updating rzk...',
+            location: vscode.ProgressLocation.Notification,
+            cancellable: false,
+          },
+          (progress) => installLatestRzk(binFolder)
+        );
       }
     });
 }

--- a/src/installRzk.ts
+++ b/src/installRzk.ts
@@ -1,0 +1,109 @@
+import * as vscode from 'vscode';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { output } from './logging';
+import {
+  fetchReleaseBinary,
+  fetchLatestCompatibleRelease,
+  // isCompatibleVersion,
+} from './githubReleases';
+import { extract } from 'tar';
+
+/**
+ * Finds the path to rzk on the user's system
+ */
+function getUserRzkPath() {
+  // Check the config variable first, then the PATH
+  const path =
+    vscode.workspace.getConfiguration().get<string | null>('rzk.path') ?? 'rzk';
+  // TODO: handle reporting errors for the config being set but not pointing to a valid executable
+  const result = spawnSync(path, ['version']);
+  if (result.status === 0) {
+    return path;
+  }
+  return null;
+}
+
+export async function installRzkIfNotExists({
+  binFolder,
+}: {
+  binFolder: vscode.Uri;
+}) {
+  const path = getUserRzkPath();
+  if (path != null) {
+    output.appendLine(`Using rzk from "${path}"`);
+    return;
+  }
+  // Create the bin folder (recursively) if it doesn't exist
+  await vscode.workspace.fs.createDirectory(binFolder);
+  const listing = await vscode.workspace.fs.readDirectory(binFolder);
+
+  /*
+  // TODO:
+  // This section has been commented out since for now we only have one executable in the binFolder
+  //  and don't keep older versions. In the future, a better approach would be to use versions in
+  //  file name itself (rather than keeping it as `rzk.exe`)
+
+  // Find the first executable that satisfies the version range the extension supports
+  const compatibleBin = listing
+    // Only files
+    .filter(([_name, type]) => type === vscode.FileType.File)
+    // Sort descending (to get latest version first)
+    .sort((a, b) => b[0].localeCompare(a[0]))
+    .find(([name, _type]) => {
+      // TODO: improve the version extraction to use RegEx or something more robust
+      // `isCompatibleVersion` uses `semver.coerce` internally, which will extract the version from the string
+      return isCompatibleVersion(name);
+    });
+  */
+  const binExtension = process.platform === 'win32' ? '.exe' : '';
+  const localBin = listing
+    .filter(([_name, type]) => type === vscode.FileType.File)
+    .find(([name, _type]) => name === `rzk${binExtension}`);
+  if (localBin) {
+    const path = join(binFolder.fsPath, localBin[0]);
+    output.appendLine('Found local installation of rzk: ' + path);
+    return;
+  }
+
+  // Ignore the returned promise to not block the rest of the code waiting for user input
+  void vscode.window
+    .showWarningMessage(
+      "Cannot find 'rzk' in PATH. Install it?",
+      'Yes',
+      'Ignore'
+    )
+    .then(async (value) => {
+      if (value === 'Yes') {
+        await installLatestRzk(binFolder);
+      }
+    });
+}
+
+async function installLatestRzk(binFolder: vscode.Uri) {
+  output.appendLine('Installing rzk...');
+  const release = await fetchLatestCompatibleRelease();
+  if (!release) {
+    vscode.window.showErrorMessage(
+      'An error occurred fetching GitHub releases!'
+    );
+    return;
+  }
+  output.appendLine(`Fetched rzk release ${release.tag_name} from GitHub`);
+  const assetBuffer = await fetchReleaseBinary(release);
+  if (!assetBuffer) {
+    output.appendLine('Failed to fetch release asset');
+    return;
+  }
+  output.appendLine(`Downloaded binary for release ${release.tag_name}`);
+
+  output.appendLine(`Extracting to "${binFolder.path}"`);
+  const assetStream = Readable.from(Buffer.from(assetBuffer));
+  const tarInputStream = extract({
+    cwd: binFolder.fsPath,
+  });
+  await pipeline(assetStream, tarInputStream);
+  output.appendLine('File extracted successfully');
+}

--- a/src/installRzk.ts
+++ b/src/installRzk.ts
@@ -12,6 +12,9 @@ import {
 } from './githubReleases';
 import { extract } from 'tar';
 
+const binExtension = process.platform === 'win32' ? '.exe' : '';
+const binName = 'rzk' + binExtension;
+
 /**
  * Finds the path to rzk on the user's system
  */
@@ -59,10 +62,9 @@ export async function installRzkIfNotExists({
       return isCompatibleVersion(name);
     });
   */
-  const binExtension = process.platform === 'win32' ? '.exe' : '';
   const localBin = listing
     .filter(([_name, type]) => type === vscode.FileType.File)
-    .find(([name, _type]) => name === `rzk${binExtension}`);
+    .find(([name, _type]) => name === binName);
   if (localBin) {
     const path = join(binFolder.fsPath, localBin[0]);
     output.appendLine('Found local installation of rzk: ' + path);
@@ -169,6 +171,22 @@ async function checkForUpdates(binPath: string, binFolder: vscode.Uri) {
           },
           (progress) => installLatestRzk(binFolder)
         );
+      }
+    });
+}
+
+export function clearLocalInstallations(binFolder: vscode.Uri) {
+  vscode.workspace.fs
+    .delete(vscode.Uri.joinPath(binFolder, binName))
+    .then(() =>
+      vscode.window.showInformationMessage(
+        'Rzk successfully removed from VS Code. Please reload the window',
+        'Reload'
+      )
+    )
+    .then((value) => {
+      if (value === 'Reload') {
+        vscode.commands.executeCommand('workbench.action.reloadWindow');
       }
     });
 }

--- a/src/installRzk.ts
+++ b/src/installRzk.ts
@@ -73,7 +73,7 @@ export async function installRzkIfNotExists({
   // Ignore the returned promise to not block the rest of the code waiting for user input
   void vscode.window
     .showWarningMessage(
-      "Cannot find 'rzk' in PATH. Install it?",
+      "Cannot find 'rzk' in PATH. Install latest version of rzk from GitHub releases?",
       'Yes',
       'Ignore'
     )

--- a/src/installRzk.ts
+++ b/src/installRzk.ts
@@ -108,6 +108,9 @@ async function installLatestRzk(binFolder: vscode.Uri) {
   });
   await pipeline(assetStream, tarInputStream);
   output.appendLine('File extracted successfully');
+  vscode.window.showInformationMessage(
+    'Rzk installed successfully. Please reload the window for the changes to take effect'
+  );
 }
 
 async function checkForUpdates(binPath: string, binFolder: vscode.Uri) {

--- a/src/installRzk.ts
+++ b/src/installRzk.ts
@@ -148,7 +148,7 @@ async function checkForUpdates(binPath: string, binFolder: vscode.Uri) {
         output.appendLine('Updating local rzk version');
         await vscode.window.withProgress(
           {
-            title: 'Updating rzk...',
+            title: `Updating rzk (v${version} => ${latestRelease.tag_name})...`,
             location: vscode.ProgressLocation.Notification,
             cancellable: false,
           },

--- a/src/installRzk.ts
+++ b/src/installRzk.ts
@@ -123,9 +123,16 @@ async function installLatestRzk(binFolder: vscode.Uri, progress?: Progress) {
   });
   await pipeline(assetStream, tarInputStream);
   output.appendLine('File extracted successfully');
-  vscode.window.showInformationMessage(
-    'Rzk installed successfully. Please reload the window for the changes to take effect'
-  );
+  vscode.window
+    .showInformationMessage(
+      'Rzk installed successfully. Please reload the window for the changes to take effect',
+      'Reload'
+    )
+    .then((value) => {
+      if (value === 'Reload') {
+        vscode.commands.executeCommand('workbench.action.reloadWindow');
+      }
+    });
 }
 
 async function checkForUpdates(binPath: string, binFolder: vscode.Uri) {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,3 @@
+import * as vscode from 'vscode';
+
+export const output = vscode.window.createOutputChannel('Rzk');

--- a/src/semanticTokens.ts
+++ b/src/semanticTokens.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import { spawnSync } from 'node:child_process';
+import { output } from './logging';
 
 // https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
 export const tokenTypes = [
@@ -49,3 +51,59 @@ export const legend = new vscode.SemanticTokensLegend(
 
 export type TokenType = (typeof tokenTypes)[number];
 export type TokenModifier = (typeof tokenModifiers)[number];
+
+interface ParsedToken {
+  line: number;
+  startCharacter: number;
+  length: number;
+  tokenType: TokenType;
+  tokenModifiers: TokenModifier[];
+}
+
+export class DocumentSemanticTokensProvider
+  implements vscode.DocumentSemanticTokensProvider
+{
+  async provideDocumentSemanticTokens(
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken
+  ): Promise<vscode.SemanticTokens> {
+    // output.appendLine(`Parsing file "${document.uri}"`);
+    const allTokens: ParsedToken[] = this._parseText(document.getText());
+    const builder = new vscode.SemanticTokensBuilder(legend);
+    allTokens.forEach((token) => {
+      builder.push(
+        new vscode.Range(
+          new vscode.Position(token.line, token.startCharacter),
+          new vscode.Position(token.line, token.startCharacter + token.length)
+        ),
+        token.tokenType,
+        token.tokenModifiers
+      );
+    });
+    return builder.build();
+  }
+
+  private _parseText(doc: string): ParsedToken[] {
+    const path =
+      vscode.workspace.getConfiguration().get<string | null>('rzk.path') ??
+      'rzk';
+    const processResult = spawnSync(path, ['tokenize'], { input: doc });
+    if (processResult.error) {
+      const { message, stack } = processResult.error;
+      output.appendLine('Error running rzk:' + message + '\n' + stack);
+      return [];
+    }
+    if (processResult.stderr.length) {
+      output.appendLine(
+        'Error tokenizing:\n' + processResult.stderr.toString()
+      );
+      return [];
+    }
+    const stdout = processResult.stdout.toString();
+    try {
+      return JSON.parse(stdout);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/semanticTokens.ts
+++ b/src/semanticTokens.ts
@@ -63,6 +63,8 @@ interface ParsedToken {
 export class DocumentSemanticTokensProvider
   implements vscode.DocumentSemanticTokensProvider
 {
+  constructor(private rzkPath: string) {}
+
   async provideDocumentSemanticTokens(
     document: vscode.TextDocument,
     token: vscode.CancellationToken
@@ -84,10 +86,7 @@ export class DocumentSemanticTokensProvider
   }
 
   private _parseText(doc: string): ParsedToken[] {
-    const path =
-      vscode.workspace.getConfiguration().get<string | null>('rzk.path') ??
-      'rzk';
-    const processResult = spawnSync(path, ['tokenize'], { input: doc });
+    const processResult = spawnSync(this.rzkPath, ['tokenize'], { input: doc });
     if (processResult.error) {
       const { message, stack } = processResult.error;
       output.appendLine('Error running rzk:' + message + '\n' + stack);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["es2020"],
     "outDir": "out",
     "sourceMap": true,
+    "esModuleInterop": true,
     "rootDir": "src",
     "strict": true
   },


### PR DESCRIPTION
Implements a prompt to install `rzk` (local to VS Code only) if it was not already found on `PATH` and not configured in the extension settings:
![image](https://github.com/fizruk/vscode-rzk/assets/11016151/9c0adfbe-6f53-48d6-89d6-b2a0b9f9f6c1)

including a progress indicator while installing:
![image](https://github.com/fizruk/vscode-rzk/assets/11016151/7c1cfcb4-a25e-44ef-b45e-358d4c6af073)

Additionally, it will prompt to update the local version (not the one from `PATH`) if updates are available on GitHub:
![image](https://github.com/fizruk/vscode-rzk/assets/11016151/843b7f56-0fc5-420c-ad5b-51b92399833d)

The installation process is simply fetching the latest compatible release on GitHub with an asset compatible with the current platform and then extracting it in the global storage location of our extension.

Resolves #21 

# Known limitations

Only the latest downloaded version is kept, so if we will support specifying the rzk version in the project settings in the future, we will need to possibly store more than one version.

It should also be better documented that installing `rzk` globally after having installed it through the extension will cause the global version (from `PATH`) to take precedence.

Lastly, version comparison is done by coercing the GitHub release tag to [semver](https://semver.org/), not PVP. This hopefully shouldn't cause a problem (according to the couple of manual tests I tried), but might limit how we can specify supported version ranges.