### PR TITLE
Automatically compile TypeScript when debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "request": "launch",
       "skipFiles": ["<node_internals>/**"],
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
-      "preLaunchTask": "Convert YAML TextMate Grammars to JSON"
+      "preLaunchTask": "Build"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,11 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Compile TypeScript",
+      "type": "npm",
+      "script": "compile"
+    },
+    {
       "label": "Convert YAML TextMate Grammars to JSON",
       "type": "process",
       "command": "bash",
@@ -13,6 +18,14 @@
         "kind": "build",
         "isDefault": true
       }
+    },
+    {
+      "label": "Build",
+      "dependsOrder": "parallel",
+      "dependsOn": [
+        "Compile TypeScript",
+        "Convert YAML TextMate Grammars to JSON"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Since it is easy to forget to run `npm run watch` while developing, this will run `compile` automatically when launching the debugger