### PR TITLE
Option to download prereleases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Extension settings can be configured by going to the settings page (using the me
 
 The currently available settings are:
 
-| Name       | Type     | Default value | Description                                                                                                                                   |
-| ---------- | -------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `rzk.path` | `string` | `""`          | The path to the `rzk` executable to use for the language server. `""` (default) means that `rzk` executable available in `PATH` will be used. |
+| Name                   | Type      | Default value | Description                                                                                                                                   |
+| ---------------------- | --------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rzk.path`             | `string`  | `""`          | The path to the `rzk` executable to use for the language server. `""` (default) means that `rzk` executable available in `PATH` will be used. |
+| `rzk.fetchPrereleases` | `boolean` | `false`       | If true, will include releases marked as \"pre-release\" on GitHub when fetching the latest binaries.                                         |

--- a/package.json
+++ b/package.json
@@ -144,6 +144,11 @@
           "default": "",
           "description": "The path and file name of the Rzk executable to use. If not set, will default to using `rzk` from the system PATH",
           "scope": "machine-overridable"
+        },
+        "rzk.fetchPrereleases": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, will include releases marked as \"pre-release\" on GitHub when fetching the latest binaries"
         }
       }
     },

--- a/src/githubReleases.ts
+++ b/src/githubReleases.ts
@@ -50,6 +50,7 @@ export async function fetchLatestCompatibleRelease(): Promise<
   const latestRelease = releases.find(
     (release) =>
       isCompatibleVersion(release.tag_name) &&
+      !release.prerelease &&
       release.assets.find(
         (asset) => asset.name === getReleaseAssetName(release)
       )

--- a/src/githubReleases.ts
+++ b/src/githubReleases.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import semver from 'semver';
 import { Octokit, type RestEndpointMethodTypes } from '@octokit/rest';
 import { output } from './logging';
@@ -45,12 +46,16 @@ export async function fetchLatestCompatibleRelease(): Promise<
     owner: 'rzk-lang',
     repo: 'rzk',
   });
+
+  const fetchPrereleases =
+    vscode.workspace.getConfiguration().get<boolean>('rzk.fetchPrereleases') ??
+    false;
   // Find the latest release that satisfies the version range the extension supports
   //   and has an asset for the current platform
   const latestRelease = releases.find(
     (release) =>
       isCompatibleVersion(release.tag_name) &&
-      !release.prerelease &&
+      (fetchPrereleases || !release.prerelease) &&
       release.assets.find(
         (asset) => asset.name === getReleaseAssetName(release)
       )


### PR DESCRIPTION
Changes the default behaviour to filter out prereleases, with an option to explicitly include them.

Closes #29