### PR TITLE
Add an option to install using a package manager

### DIFF
--- a/src/installRzk.ts
+++ b/src/installRzk.ts
@@ -79,7 +79,7 @@ export async function installRzkIfNotExists({
     .showWarningMessage(
       "Cannot find 'rzk' in PATH. Install latest version of rzk from GitHub releases?",
       'Yes',
-      'Build from source',
+      'Build via...',
       'Ignore'
     )
     .then(async (value) => {
@@ -96,7 +96,7 @@ export async function installRzkIfNotExists({
             return installLatestRzk(binFolder, progress);
           }
         );
-      } else if (value === 'Build from source') {
+      } else if (value === 'Build via...') {
         const choice = await vscode.window.showQuickPick(
           ['stack', 'cabal'],
           {
@@ -106,7 +106,7 @@ export async function installRzkIfNotExists({
           }
         );
         if (choice === undefined) return;
-        output.appendLine('Building from source using ' + choice);
+        output.appendLine('Building via ' + choice);
         await vscode.window.withProgress(
           {
             location: vscode.ProgressLocation.Notification,

--- a/src/installRzk.ts
+++ b/src/installRzk.ts
@@ -98,7 +98,7 @@ export async function installRzkIfNotExists({
         );
       } else if (value === 'Build from source') {
         const choice = await vscode.window.showQuickPick(
-          ['stack', 'cabal', 'nix'],
+          ['stack', 'cabal'],
           {
             title: 'This will install rzk globally on your system',
             ignoreFocusOut: true,
@@ -106,12 +106,6 @@ export async function installRzkIfNotExists({
           }
         );
         if (choice === undefined) return;
-        if (choice === 'nix') {
-          vscode.window.showWarningMessage(
-            'Sorry, Nix installation is not supported yet :('
-          );
-          return;
-        }
         output.appendLine('Building from source using ' + choice);
         await vscode.window.withProgress(
           {


### PR DESCRIPTION
~~WIP: waiting to figure out how to install via Nix properly.~~ Does not support installing via Nix (yet)

![image](https://github.com/rzk-lang/vscode-rzk/assets/11016151/eba471ba-5c89-4461-8c6a-56f578c8b052)
![image](https://github.com/rzk-lang/vscode-rzk/assets/11016151/cb5eea4a-f623-4bca-9bed-6cbc6c36df7b)
![image](https://github.com/rzk-lang/vscode-rzk/assets/11016151/9eeadc0f-b89a-488e-b6e6-7962afc5b718)


Known shortcomings:
- **Updating** (after the initial installation) via a package manager is not supported since it doesn't currently store how `rzk` was installed. I think it is possible to just give the same 3 options again, but that feels error-prone.

Closes #41