### PR TITLE
Add default settings for formatting Rzk files

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
         "editor.rulers": [
           80
         ],
+        "editor.detectIndentation": false,
         "editor.tabSize": 2,
         "editor.insertSpaces": true,
         "files.trimTrailingWhitespace": true,

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
         ],
         "editor.detectIndentation": false,
         "editor.tabSize": 2,
+        "editor.formatOnSave": true,
         "editor.insertSpaces": true,
         "files.trimTrailingWhitespace": true,
         "files.insertFinalNewline": true

--- a/package.json
+++ b/package.json
@@ -141,6 +141,11 @@
     "configuration": {
       "title": "Rzk",
       "properties": {
+        "rzk.format.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable the Rzk formatter"
+        },
         "rzk.path": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,18 @@
         }
       }
     },
+    "configurationDefaults": {
+      "[rzk][literate rzk markdown]": {
+        "editor.defaultFormatter": "NikolaiKudasovfizruk.rzk-1-experimental-highlighting",
+        "editor.rulers": [
+          80
+        ],
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true,
+        "files.trimTrailingWhitespace": true,
+        "files.insertFinalNewline": true
+      }
+    },
     "menus": {
       "editor/title": [
         {


### PR DESCRIPTION
Sets the extension itself as the default formatter (using LSP, which depends on the upcoming release of Rzk) for Rzk files, while also adding other relevant sensible defaults.

I also contemplated adding
```json
"editor.formatOnSave": true
```
but I'm not if the formatter is ready enough for that. It can cause frustration to users who prefer not to opt in for the formatter, especially that they are not used to it existing in Rzk (coming with the next release). What do you think?

**Edit**: received reply privately: it should be turned on by default, since users can disable the formatter